### PR TITLE
adds secure closet hacking

### DIFF
--- a/modular_brazuca/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/modular_brazuca/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -1,0 +1,22 @@
+/obj/structure/closet/secure_closet
+	var/panel_open = 0
+	var/l_hacking = 0
+
+/obj/structure/closet/secure_closet/attackby(obj/item/weapon/W, mob/user, params)
+	..()
+	if(istype(W, /obj/item/tool/screwdriver))
+		panel_open = !panel_open
+		to_chat(user, "<span class='notice'>You [panel_open ? "open" : "close"] the service panel.</span>")
+	else if(istype(W, /obj/item/device/multitool) && panel_open && !l_hacking)
+		to_chat(user, "<span class='danger'>Now attempting to reset internal memory, please hold.</span>")
+		l_hacking = 1
+		if(do_after(user, 100, target = src))
+			if(prob(40))
+				to_chat(user, "<span class='danger'>Internal memory reset.  Please give it a few seconds to reinitialize.</span>")
+				sleep(rand(40, 80))
+				locked = 0
+				update_icon()
+			else
+				to_chat(user, "<span class='danger'>Unable to reset internal memory.</span>")
+		l_hacking = 0
+

--- a/vgstation13.dme
+++ b/vgstation13.dme
@@ -2887,4 +2887,5 @@
 #include "maps\RandomZLevels\stationCollision.dm"
 #include "maps\RandomZLevels\tomb.dm"
 #include "maps\RandomZLevels\wildwest.dm"
+#include "modular_brazuca\code\game\objects\structures\crates_lockers\closets\secure\secure_closets.dm"
 // END_INCLUDE


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
<!-- Describe here all changes included in the PR. -->
<!-- If the PR addresses existing issues, here is where you would write "Closes #99999". See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
Allows secure closet hacking.
## Why it's good
<!-- Explain why you think these changes are good. -->
A much needed change that allows someone to hack into secure closets with screwdrivers and multitools.
## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * rscadd: Added secure closet hacking.